### PR TITLE
fix: add prerequisite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
           make fmt
           make vet
           git diff --exit-code
+      - name: Install Prerequisites
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+          GOBIN=${HOME}/.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator \
+          go install open-cluster-management.io/policy-generator-plugin/cmd/PolicyGenerator@latest
       - name: Build
         run: make build
       - name: Run unit tests

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Provide seamless integration with compliance frameworks and existing policy engi
 - [Open Cluster Management Policy Framework](https://open-cluster-management.io/) (for Kubernetes resources)
     - OCM is a multi-cluster management platform that provides governance of Kubernetes policies. [Its policy framework](https://open-cluster-management.io/concepts/policy/) allows for the validation and enforcement of policies across multiple clusters.
 
+## Prerequisite
+- Install [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/binaries/)
+- Install [policy-generator plugin](https://github.com/open-cluster-management-io/policy-generator-plugin?tab=readme-ov-file)
+
 ## Usage of C2P CLI
 ```
 $ c2pcli -h        


### PR DESCRIPTION
Signed-off-by: Takumi Yanagawa <yana@jp.ibm.com>

I have added Prerequisite for Kustomize installation. 
Now the unit test passed: https://github.com/yana1205/compliance-to-policy-go/actions/runs/11713699498/job/32626950482.

Related issue: https://github.com/oscal-compass/compliance-to-policy-go/pull/1#issuecomment-2461022823